### PR TITLE
Add URL loader demo page

### DIFF
--- a/demo/url-player.html
+++ b/demo/url-player.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Omakase Player URL Loader</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@byomakase/omakase-player@0.19.0/dist/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@byomakase/omakase-player@0.19.0/dist/omakase-player.umd.min.js"></script>
+  <style>
+    body { font-family: Arial; padding: 20px; }
+    #omakase-player { margin-top: 20px; width: 640px; height: 360px; }
+  </style>
+</head>
+<body>
+  <div>
+    <label for="videoUrl">Video URL:</label>
+    <input type="text" id="videoUrl" placeholder="https://example.com/video.m3u8" style="width: 400px;">
+    <button id="loadBtn">Load</button>
+  </div>
+  <div id="omakase-player"></div>
+
+  <script>
+    const player = new OmakasePlayer({playerHTMLElementId: 'omakase-player'});
+    document.getElementById('loadBtn').addEventListener('click', () => {
+      const url = document.getElementById('videoUrl').value;
+      if (url) {
+        player.loadVideo(url, { frameRate: 30 }).subscribe();
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `demo/url-player.html` for loading a custom video URL into the Omakase Player

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_687d5edff9448328b18a2ddf994dff10